### PR TITLE
fix: correct OpenShift SecurityContextConstraints guidance

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -281,15 +281,18 @@ spec:
 
 **2. SecurityContextConstraints**
 
-If your cluster enforces the `restricted` SCC, add to the Conductor pod spec:
+The community image runs as **root (UID 0)**. The startup script launches nginx (which binds port 5000) and writes logs to `/app/logs/server.log` — both operations require root. This means the image is **incompatible with the `restricted` SCC** and with `runAsNonRoot: true`.
 
-```yaml
-securityContext:
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
+To run on OpenShift, grant the `anyuid` or `privileged` SCC to the service account in the `conductor` namespace:
+
+```shell
+oc adm policy add-scc-to-user anyuid -z default -n conductor
 ```
 
+> **Do not** add a `securityContext: runAsNonRoot: true` block to the Conductor pod spec — it will prevent nginx from starting and the UI will be unavailable.
+
 If the PostgreSQL pod fails to start due to volume permission issues, add `fsGroup: 999` to its pod spec (999 is the `postgres` GID in the official image).
+
+> **Note on UI availability:** The UI is bundled in the community image and served by nginx on port 5000. If the UI Route returns "Application not available", the most common cause is nginx failing to start due to a restrictive security context — check the pod logs for `Permission denied` errors and verify the SCC grants above have been applied.
 
 `oc` users: all `kubectl` commands in this guide work identically with `oc`.


### PR DESCRIPTION
## Summary

Fixes two documentation bugs found by inspecting the actual community image (`orkesio/orkes-conductor-community:3.30.0.rc16`).

**Fix 1: OpenShift SecurityContextConstraints (closes #55)**
- The previous docs recommended `runAsNonRoot: true` for OpenShift's `restricted` SCC — this always breaks the container because the image runs as root (UID 0), nginx must bind port 5000, and the server writes to `/app/logs/server.log`
- Replaced with the correct `oc adm policy add-scc-to-user anyuid` command
- Added a note explaining that "Application not available" on the UI Route is caused by nginx failing to start due to a restrictive security context

**Fix 2: OpenSearch indexing not supported in community image (closes #56)**
- The docs described OpenSearch 2.x and 3.x as the indexing backend, but the community image only bundles `conductor-es7-persistence` — no OpenSearch modules at all
- Setting `conductor.indexing.type=opensearch2` or `opensearch3` fails at startup with `No qualifying bean of type 'com.netflix.conductor.dao.IndexDAO'`
- Replaced the OpenSearch section with Elasticsearch 7 instructions, using the correct property names (`conductor.elasticsearch.*`) and type value (`elasticsearch`)
- Added a prominent callout warning that OpenSearch is not supported in the community image

Both verified by pulling the images and inspecting the bundled jars directly.